### PR TITLE
redo #97, return regression regions for all citations endpoint

### DIFF
--- a/NSSAgent/NSSAgent.cs
+++ b/NSSAgent/NSSAgent.cs
@@ -97,8 +97,6 @@ namespace NSSAgent
         Task<IEnumerable<RegressionRegion>> Add(List<NSSDB.Resources.RegressionRegion> items);
         Task<RegressionRegion> Update(Int32 pkId, NSSDB.Resources.RegressionRegion item);
         Task DeleteRegressionRegion(Int32 pkID);
-        IQueryable<object> GroupRegressionRegionsByCitation(IQueryable<RegressionRegion> regRegionList = null);
-
         //Coefficents
         IQueryable<Coefficient> GetRegressionRegionCoefficients(Int32 RegressionRegionID);
         Task<IEnumerable<Coefficient>> AddRegressionRegionCoefficients(Int32 RegressionRegionID, List<Coefficient> items);
@@ -167,7 +165,7 @@ namespace NSSAgent
         public IQueryable<Citation> GetCitations(List<String> regionList=null, IGeometry geom = null, List<String> regressionRegionList = null, List<String> statisticgroupList = null, List<String> regressiontypeList = null)
         {
             if (!regionList.Any() && geom == null && !regressionRegionList.Any()&& !statisticgroupList.Any() && !regressiontypeList.Any())
-                return this.Select<Citation>();
+                return this.Select<Citation>().Include(c => c.RegressionRegions);
             if (statisticgroupList?.Any() != true && regressiontypeList?.Any() != true && !regressiontypeList.Any() != true && geom == null)
                 // for region only list
                 return Select<RegionRegressionRegion>().Include(rrr => rrr.Region).Include(rrr => rrr.RegressionRegion).ThenInclude(rr=>rr.Citation)
@@ -448,15 +446,6 @@ namespace NSSAgent
 
             return query.Select(rrr => rrr.RegressionRegion).Distinct();
 
-        }
-        public IQueryable<object> GroupRegressionRegionsByCitation(IQueryable<RegressionRegion> regRegions = null)
-        {
-            var query = regRegions.GroupBy(rr => rr.CitationID).Select(g => new
-            {
-                citationID = g.Key,
-                regressionRegions = g.Select(c => c)
-            });
-            return query;
         }
         public IQueryable<RegressionRegion> GetRegressionRegion(int regregionID, bool getPolygon = false)
         {

--- a/NSSServices/Controllers/RegressionRegionsController.cs
+++ b/NSSServices/Controllers/RegressionRegionsController.cs
@@ -44,7 +44,7 @@ namespace NSSServices.Controllers
         [HttpGet(Name ="Regression Regions")]
         [HttpGet("/Regions/{regions}/[controller]",Name ="Region Regression Regions")]
         [APIDescription(type = DescriptionType.e_link, Description = "/Docs/RegressionRegions/Get.md")]
-        public async Task<IActionResult> Get(string regions = "", [FromQuery] string statisticgroups = "", [FromQuery] string regressiontypes = "", [FromQuery] bool bycitation = false)
+        public async Task<IActionResult> Get(string regions = "", [FromQuery] string statisticgroups = "", [FromQuery] string regressiontypes = "")
         {
             IQueryable<RegressionRegion> entities = null;
             List<string> RegionList = null;
@@ -64,10 +64,6 @@ namespace NSSServices.Controllers
                 else
                     entities = agent.GetRegressionRegions(RegionList,null, statisticgroupList,regressiontypeList);
 
-                if (bycitation)
-                {
-                    return Ok(agent.GroupRegressionRegionsByCitation(entities));
-                }
                 sm($"regression region count {entities.Count()}");
                 return Ok(entities);
             }

--- a/NSSServices/appsettings.json
+++ b/NSSServices/appsettings.json
@@ -103,9 +103,6 @@
             "method": "GET"
           }
         },
-        "bycitation": {
-          "description": "A boolean value signifying whether to group the regressions by citation ID."
-        },
         "getpolygon": {
           "description": "A boolean value signifying whether to send back a geojson of the regression region polygon."
         }

--- a/NSSServices/web.config
+++ b/NSSServices/web.config
@@ -8,7 +8,7 @@
       <handlers>
         <remove name="aspNetCore" />
         <remove name="WebDAV" />
-        <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModule" resourceType="Unspecified" />
+        <add name="aspNetCore" path="*" verb="*" modules="AspNetCoreModuleV2" resourceType="Unspecified" />
       </handlers>
       <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout">
         <environmentVariables />


### PR DESCRIPTION
- remove "group regression region by citation" functionality (not sure why I did it this way)
- add regression regions to each citation at get all citations endpoint (for purpose of using it in the client "manage citations" modal)

I couldn't revert the original pull request, but it was simple enough that just removing each change manually worked