### PR TITLE
changes to force update, fixes #165

### DIFF
--- a/Docs/Variables/Batch.md
+++ b/Docs/Variables/Batch.md
@@ -15,12 +15,14 @@ content-length: 576
 [{
     "name":"Example Variable Type 1",
     "code":"EXVARTYPE1"
-    "description": "First variable type example"
+    "description": "First variable type example",
+    "unitTypeID": "1"
 },
 {
     "name":"Example Variable Type 2",
     "code":"EXVARTYPE2"
-    "description": "Second variable type example"
+    "description": "Second variable type example",
+    "unitTypeID": "1"
 }]
 ```
 
@@ -30,12 +32,14 @@ HTTP/1.1 200 OK
 	"id": 25,
 	"name":"Example Variable Type 1",
     "code":"EXVARTYPE1"
-    "description": "First variable type example"
+    "description": "First variable type example",
+    "unitTypeID": "1"
 },
 {
 	"id": 26,
 	"name":"Example Variable Type 2",
     "code":"EXVARTYPE2"
-    "description": "Second variable type example"
+    "description": "Second variable type example",
+    "unitTypeID": "1"
 }]
 ```

--- a/Docs/Variables/summary.md
+++ b/Docs/Variables/summary.md
@@ -1,1 +1,1 @@
-The variable resource represents the variable type, also called the parameter or stat label, of a characteristic, such as Drainage Area (DRNAREA).
+The variable resource represents the variable type, also called the parameter or stat label, of a characteristic, such as Drainage Area (DRNAREA). Many variables also contain a "unitTypeID", defining the default unit type for each variable.

--- a/FU_NSSDB.Test/ForceUpdateTest.cs
+++ b/FU_NSSDB.Test/ForceUpdateTest.cs
@@ -24,7 +24,7 @@ namespace FU_NSSDB.Test
                 var username = Configuration["dbuser"];
                 var password = Configuration["dbpassword"];
 
-                var x = new ForceUpdate(username, password, @"C:\Users\kjacobsen\Documents\wim_projects\docs\ss\nss\SSDB\StreamStatsDB_2020-07-29.mdb");
+                var x = new ForceUpdate(username, password, @"C:\Users\kjacobsen\Documents\wim_projects\docs\ss\nss\SSDB\StreamStatsDB_2020-09-03.mdb");
                 if (x.VerifyLists())
                 {
                     x.Load();

--- a/FU_NSSDB/NSSdbOps.cs
+++ b/FU_NSSDB/NSSdbOps.cs
@@ -105,7 +105,7 @@ namespace FU_NSSDB
             string sql = string.Empty;
             try
             {
-                sql += @"TRUNCATE TABLE ""Regions"" RESTART IDENTITY CASCADE;
+                sql += @"TRUNCATE TABLE ""shared"".""Regions"" RESTART IDENTITY CASCADE;
                          TRUNCATE TABLE ""RegionRegressionRegions"" RESTART IDENTITY CASCADE;";
                 sql += @"TRUNCATE TABLE ""RegressionRegions"" RESTART IDENTITY CASCADE;
                          TRUNCATE TABLE ""Citations"" RESTART IDENTITY CASCADE;";
@@ -235,7 +235,7 @@ namespace FU_NSSDB
             switch (type)
             {
                 case SQLType.e_region:
-                    results = @"INSERT INTO ""nss"".""Regions""(""Name"",""Code"") VALUES('{0}','{1}')";
+                    results = @"INSERT INTO ""shared"".""Regions""(""Name"",""Code"") VALUES('{0}','{1}')";
                     break;
                 case SQLType.e_regressionregion:
                     results = @"INSERT INTO ""nss"".""RegressionRegions""(""Name"",""Code"",""Description"",""CitationID"",""StatusID"") VALUES('{0}', '{1}', '{2}',{3}, {4})";

--- a/FU_NSSDB/SQL_files/A_tableUpdates.sql
+++ b/FU_NSSDB/SQL_files/A_tableUpdates.sql
@@ -464,6 +464,17 @@ INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES
 INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (658,40,'Default unit');
 INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (659,40,'Default unit');
 INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (667,58,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (799,35,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (800,11,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (801,35,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (812,1,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (813,1,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (814,1,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (815,1,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (816,40,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (817,40,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (818,40,'Default unit');
+INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (819,40,'Default unit');
 
 /*update regions*/
 UPDATE "nss"."Regions" SET "Code" = 'MO_STL' WHERE "Code" = 'SL';

--- a/FU_NSSDB/SQL_files/A_tableUpdates.sql
+++ b/FU_NSSDB/SQL_files/A_tableUpdates.sql
@@ -467,14 +467,6 @@ INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES
 INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (799,35,'Default unit');
 INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (800,11,'Default unit');
 INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (801,35,'Default unit');
-INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (812,1,'Default unit');
-INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (813,1,'Default unit');
-INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (814,1,'Default unit');
-INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (815,1,'Default unit');
-INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (816,40,'Default unit');
-INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (817,40,'Default unit');
-INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (818,40,'Default unit');
-INSERT INTO "nss"."Variables"("VariableTypeID", "UnitTypeID", "Comments") VALUES (819,40,'Default unit');
 
 /*update regions*/
 UPDATE "nss"."Regions" SET "Code" = 'MO_STL' WHERE "Code" = 'SL';

--- a/NSSDB/Migrations/20200825141040_moveManagersToShared.cs
+++ b/NSSDB/Migrations/20200825141040_moveManagersToShared.cs
@@ -100,6 +100,20 @@ namespace NSSDB.Migrations
                 schema: "shared",
                 table: "Regions",
                 column: "Code");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_RegionRegressionRegions_Regions_RegionID",
+                schema: "nss",
+                table: "RegionRegressionRegions");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RegionRegressionRegions_Regions_RegionID",
+                schema: "nss",
+                table: "RegionRegressionRegions",
+                column: "RegionID",
+                principalTable: "Regions",
+                principalSchema: "shared",
+                onDelete: ReferentialAction.Cascade);
         }
 
         protected override void Down(MigrationBuilder migrationBuilder)
@@ -111,15 +125,29 @@ namespace NSSDB.Migrations
 
             migrationBuilder.DropTable(
                 name: "Regions",
-                schema: "nss");
+                schema: "shared");
 
             migrationBuilder.DropTable(
                 name: "Managers",
-                schema: "nss");
+                schema: "shared");
 
             migrationBuilder.DropTable(
                 name: "RegionManager",
-                schema: "nss");
+                schema: "shared");
+
+            migrationBuilder.DropForeignKey(
+               name: "FK_RegionRegressionRegions_Regions_RegionID",
+               schema: "nss",
+               table: "RegionRegressionRegions");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RegionRegressionRegions_Regions_RegionID",
+                schema: "nss",
+                table: "RegionRegressionRegions",
+                column: "RegionID",
+                principalTable: "Regions",
+                principalSchema: "nss",
+                onDelete: ReferentialAction.Cascade);
         }
     }
 }

--- a/NSSDB/Migrations/moveManagersToShared.sql
+++ b/NSSDB/Migrations/moveManagersToShared.sql
@@ -494,3 +494,6 @@ VALUES (4, 'U', 'Undefined');
 INSERT INTO nss."_EFMigrationsHistory" ("MigrationId", "ProductVersion")
 VALUES ('20200825141040_moveManagersToShared', '3.1.3');
 
+ALTER TABLE nss."RegionRegressionRegions" DROP CONSTRAINT "FK_RegionRegressionRegions_Regions_RegionID";
+
+ALTER TABLE nss."RegionRegressionRegions" ADD CONSTRAINT "FK_RegionRegressionRegions_Regions_RegionID" FOREIGN KEY ("RegionID") REFERENCES shared."Regions" ("ID") ON DELETE CASCADE;


### PR DESCRIPTION
- fixes #165 - update service doc for vars w/ unit
- changes to force update - mainly associated with recent migration of regions table to shared db and new variable types
- also added in changes to migrations - small issue left over from #156 

Note: the force update changes just affect running the script, so there's no way to test those in the services, other than to double check that things look good from my recent run of it (https://test.streamstats.usgs.gov/nss-dev/)