### PR TITLE
Fixes #263

### DIFF
--- a/NSSAgent/Resources/RegressionResult.cs
+++ b/NSSAgent/Resources/RegressionResult.cs
@@ -20,7 +20,8 @@ namespace NSSAgent.Resources
         [Required]
         public string code { get; set; }
         public string Description { get; set; }
-        public Double? Value { get; set; }        
+        public Double? Value { get; set; }
+        public Double? SEP { get; set; }
         public List<Error> Errors { get; set; }
         [XmlElement("UnitType")]
         [Required]


### PR DESCRIPTION
In the `evaluateUncertainty` function I outputted intervalBounds along with Si which is SEP. Everywhere that called the `evaluateUncertainty` function (which was two places), I named the object it returned `intervalsAndSEP`. Then when the code needed either SEP or interval bounds from that object I called it using `intervalsAndSEP?.intervalBounds` or `intervalsAndSEP?.Si`.

I tested multiple states and options in NSS (some with variable values too high and some too low) and compared to the working NSS values and all looks good. Then in SS I tested basins in multiple states and I tested basins between two states. Using these two methods I was able to create a bunch of service calls to the estimate endpoint on both dev and local and compared using text  compare, and the only differences I noticed was an SEP output in the results. 