### PR TITLE
Fixes #238

### DIFF
--- a/NSSAgent/NSSAgent.cs
+++ b/NSSAgent/NSSAgent.cs
@@ -173,15 +173,10 @@ namespace NSSAgent
         {
             return this.Find<Citation>(ID);
         }
-        public IQueryable<Citation> GetCitations(List<String> regionList=null, Geometry geom = null, List<String> regressionRegionList = null, List<String> statisticgroupList = null, List<String> regressiontypeList = null, IQueryable<Status> applicableStatus = null)
+        public IQueryable<Citation> GetCitations(List<String> regionList = null, Geometry geom = null, List<String> regressionRegionList = null, List<String> statisticgroupList = null, List<String> regressiontypeList = null, IQueryable<Status> applicableStatus = null)
         {
             if (!regionList.Any() && geom == null && !regressionRegionList.Any()&& !statisticgroupList.Any() && !regressiontypeList.Any())
                 return this.Select<Citation>().Include(c => c.RegressionRegions);
-            if (statisticgroupList?.Any() != true && regressiontypeList?.Any() != true && regressiontypeList.Any() != true && geom == null)
-                // for region only list
-                return Select<RegionRegressionRegion>().Include(rrr => rrr.Region).Include(rrr => rrr.RegressionRegion).ThenInclude(rr=>rr.Citation)
-                       .Where(rer => (regionList.Contains(rer.Region.Code.ToLower().Trim())
-                               || regionList.Contains(rer.RegionID.ToString())) && rer.RegressionRegion.CitationID !=null).Select(r => r.RegressionRegion.Citation).Distinct().AsQueryable();
             
             if (geom != null)
                 regressionRegionList = getRegressionRegionsByGeometry(geom).Select(rr => rr.ID.ToString()).ToList();


### PR DESCRIPTION
Removed code that was causing the get citation endpoint when filtering by regression type to return as an empty array. 
It broke during this push https://github.com/USGS-WiM/NSSServices/commit/c26ea9fd59d262884178e6c16604bf2f0cefb846, line 180. 

The if statement that was removed was always returning false because it was checking the `regressiontypeList ` twice and they were both different, so it was always false (up until 5 months ago when an `!` was added before one of them). The citation endpoint was working up until this point so we decided this could just be removed.

I tested with a local NSS and SS client (to make sure citations were being printed again) along with the below insomnia tests. 

[Insomnia_2021-12-16 (2).zip](https://github.com/USGS-WiM/NSSServices/files/7730396/Insomnia_2021-12-16.2.zip)
